### PR TITLE
fixing missing quote in html tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
There was a missing quote in the opening `html` tag. This led to hard-to-track down errors when importing libraries with shadow-cljs:
https://github.com/thheller/shadow-cljs/issues/306#issuecomment-401798924

